### PR TITLE
Fix README links and installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 </p>
 
 
-![Discord Theme Preview](assets/asset.png)
+![Floris Board Theme Preview](assets/asset.png)
 
 ## USAGE
 
@@ -23,7 +23,6 @@
 5. Click on the `+` icon
 6. Import
 7. Select the file
-8. Select the file
 
 ## 🙋 FAQ
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 </h3>
 
 <p align="center">
-    <a href="https://github.com/catppuccin/discord/stargazers"><img src="https://img.shields.io/github/stars/catppuccin/discord?colorA=363a4f&colorB=b7bdf8&style=for-the-badge"></a>
-    <a href="https://github.com/catppuccin/discord/issues"><img src="https://img.shields.io/github/issues/catppuccin/discord?colorA=363a4f&colorB=f5a97f&style=for-the-badge"></a>
-    <a href="https://github.com/catppuccin/discord/contributors"><img src="https://img.shields.io/github/contributors/catppuccin/discord?colorA=363a4f&colorB=a6da95&style=for-the-badge"></a>
+    <a href="https://github.com/catppuccin/floris-board/stargazers"><img src="https://img.shields.io/github/stars/catppuccin/floris-board?colorA=363a4f&colorB=b7bdf8&style=for-the-badge"></a>
+    <a href="https://github.com/catppuccin/floris-board/issues"><img src="https://img.shields.io/github/issues/catppuccin/floris-board?colorA=363a4f&colorB=f5a97f&style=for-the-badge"></a>
+    <a href="https://github.com/catppuccin/floris-board/contributors"><img src="https://img.shields.io/github/contributors/catppuccin/floris-board?colorA=363a4f&colorB=a6da95&style=for-the-badge"></a>
 </p>
 
 


### PR DESCRIPTION
The README was pointing to catppuccin/discord for the repos stats. Also, there was a duplicate step.