### PR TITLE
Changed Releases link from */newest to */latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 ## USAGE
 
-1. Download the file ([Releases](https://github.com/catppuccin/floris-board/releases/newest))
+1. Download the file ([Releases](https://github.com/catppuccin/floris-board/releases/latest))
 2. Open the app
 3. Click on Theme
 4. Click on `Manage Installed Themes`


### PR DESCRIPTION
An attempt was made to direct the user to the latest release, but the wrong link was used. Should be using https://github.com/catppuccin/floris-board/releases/latest instead.