### PR TITLE
Fix popup uri sizing

### DIFF
--- a/florisboard.tera
+++ b/florisboard.tera
@@ -110,6 +110,10 @@ secondary: "lavender"
     "background": "var(--focused-popup-surface)",
     "shape": "var(--shape)"
   },
+  "key-popup-element[code=-255]": {
+      "font-size": "18sp",
+      "text-max-lines": "1"
+  },
   "key-popup-extended-indicator": {
     "font-size": "16sp"
   },

--- a/florisboard.tera
+++ b/florisboard.tera
@@ -46,6 +46,36 @@ secondary: "lavender"
     "foreground": "var(--on-background)",
     "clip": "no"
   },
+  "window[windowmode=`floating`]": {
+    "shadow-elevation": "8dp",
+    "shape": "rounded-corner(5%, 5%, 5%, 5%)"
+  },
+  "window-move-handle[windowmode=`fixed`]": {
+      "background": "var(--surface)",
+      "foreground": "var(--primary)",
+      "font-size": "24sp",
+      "margin": "16dp 0dp",
+      "padding": "8dp",
+      "shape": "circle()"
+   },
+  "window-resize-handle": {
+    "background": "var(--primary)"
+  },
+  "window-resize-action[windowmode=`fixed`]": {
+    "background": "var(--primary)",
+    "foreground": "var(--on-primary)",
+    "font-size": "24sp",
+    "padding": "8dp",
+    "shape": "circle()"
+  },
+  "window-resize-action[windowmode=`floating`]": {
+    "background": "var(--surface)",
+    "foreground": "var(--primary)",
+    "shape": "circle()"
+  },
+  "floating-dock-to-fixed-indicator": {
+    "background": "var(--primary)"
+  },
 
   "key": {
     "background": "var(--{% if variant == "_borderless" %}background{% else %}surface{% endif %})",


### PR DESCRIPTION
This PR fixes a bug in the theme where the popup URI was displayed to big [^1]. You can test the changes with the artifact from this FlorisBoard PR [^2] as the upcoming version (v0.5.2) is not yet released. 

[^1]: https://github.com/florisboard/florisboard/issues/3062
[^2]: https://github.com/florisboard/florisboard/pull/3150